### PR TITLE
Fix example to follow CQS principle

### DIFF
--- a/JavaScript/2-separated.js
+++ b/JavaScript/2-separated.js
@@ -1,16 +1,6 @@
 'use strict';
 
-const adder = (initial) => {
-  let value = initial;
-  return (x) => {
-    let result;
-    if (x !== undefined) {
-      value += x;
-      result = value;
-    }
-    return result;
-  };
-};
+const adder = (value) => (x) => (x ? void (value += x) : value);
 
 const a1 = adder(2);
 


### PR DESCRIPTION
The `2-separated` example violated CQS principle. 
Function `adder` should return value only if argument x is not passed and mutate its own internal state otherwise. Instead, current implementation mutates state and returns value, when x is passed, and returns undefined otherwise.

The new code snippet fix the logic. Besides, usage of **void** key word and ternary operator simplify the code to one-line function.